### PR TITLE
회원 스케줄 홈 화면 및 하루 스케쥴 상세 화면 구현

### DIFF
--- a/lib/common/colors.dart
+++ b/lib/common/colors.dart
@@ -9,3 +9,4 @@ const Color BORDER_COLOR = Color(0xff3c3c3c);
 const Color BTN_COLOR = Color(0xff494949);
 const Color INDICATOR_COLOR = Color(0xff151515);
 const Color TERITARY_COLOR = Color(0xff7A7A7A);
+const Color CALENDAR_PICKED_COLOR = Color(0xffff7575);

--- a/lib/components/common_header.dart
+++ b/lib/components/common_header.dart
@@ -11,7 +11,7 @@ class CommonHeader extends StatelessWidget {
     return Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
       IconButton(
         icon: Image.asset(
-          'assets/images/images/icon_nav_arrow_left.png',
+          'assets/images/icon_nav_arrow_left.png',
           height: 24,
           width: 24,
         ),

--- a/lib/components/state_date_time.dart
+++ b/lib/components/state_date_time.dart
@@ -6,7 +6,6 @@ class StateDateTime with ChangeNotifier {
   StateDateTime({required this.selectedDateTime});
 
   void changeStateDate(DateTime selectedDateTime) {
-    print('here : $selectedDateTime');
     if (this.selectedDateTime.isAtSameMomentAs(selectedDateTime)) {
       return;
     }

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_home_calendar.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_home_calendar.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
+import '../../../../common/colors.dart';
+
 class GymbieHomeCalendar extends StatefulWidget {
   const GymbieHomeCalendar({Key? key}) : super(key: key);
 
@@ -15,13 +17,13 @@ class GymbieHomeCalendar extends StatefulWidget {
 }
 
 class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
-
   late Future<Set<String>> futureSchedules;
 
   @override
   void initState() {
     super.initState();
-    futureSchedules = fetchScheduleList(DateTime.now().year, DateTime.now().month);
+    futureSchedules =
+        fetchScheduleList(DateTime.now().year, DateTime.now().month);
   }
 
   Future<Set<String>> fetchScheduleList(int year, int month) async {
@@ -55,9 +57,7 @@ class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
     //event loader 용 함수
     List<bool> getScheduleEvents(DateTime day) {
       if (schedules.contains(
-          "${day.year}-${day.month < 10 ? "0" : ""}${day.month}-${day.day < 10
-              ? "0"
-              : ""}${day.day}")) {
+          "${day.year}-${day.month < 10 ? "0" : ""}${day.month}-${day.day < 10 ? "0" : ""}${day.day}")) {
         return [true];
       }
       return [];
@@ -84,6 +84,10 @@ class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
         weekendTextStyle: defaultTextStyle,
         outsideTextStyle: TextStyle(color: Colors.white24),
         tablePadding: EdgeInsets.all(4),
+        selectedDecoration: BoxDecoration(
+          color: CALENDAR_PICKED_COLOR,
+          shape: BoxShape.circle,
+        ),
       ),
       onDaySelected: (DateTime selectedDay, DateTime focusedDay) {
         Provider.of<StateDateTime>(context, listen: false)
@@ -95,7 +99,7 @@ class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
           return Container(
             width: 35,
             decoration: BoxDecoration(
-                color: Colors.white.withOpacity(0.6), shape: BoxShape.circle),
+                color: Colors.white.withOpacity(0.5), shape: BoxShape.circle),
           );
         }
         return null;
@@ -109,7 +113,7 @@ class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
       onPageChanged: (DateTime day) {
         Provider.of<StateDateTime>(context, listen: false).changeStateDate(day);
         setState(() {
-          futureSchedules =  fetchScheduleList(day.year, day.month);
+          futureSchedules = fetchScheduleList(day.year, day.month);
         });
       },
     );

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
@@ -8,8 +8,8 @@ import 'package:provider/provider.dart';
 import '../../../../common/colors.dart';
 import '../../../../services/models/schedule_info.dart';
 
-class ScheduleList extends StatelessWidget {
-  const ScheduleList({super.key});
+class GymbieScheduleList extends StatelessWidget {
+  const GymbieScheduleList({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ffi';
 
 import 'package:flutter/material.dart';
 import 'package:gymming_app/components/state_date_time.dart';
@@ -30,7 +29,7 @@ class GymbieScheduleList extends StatelessWidget {
             item["trainer_name"],
             item["center_name"],
             item["center_location"],
-            5);
+            5); //todo remain time 계산하기
         result.add(schedule);
       }
       return result;

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
@@ -8,8 +8,8 @@ import 'package:provider/provider.dart';
 import '../../../../common/colors.dart';
 import '../../../../services/models/schedule_info.dart';
 
-class GymbieScheduleList extends StatelessWidget {
-  const GymbieScheduleList({super.key});
+class ScheduleList extends StatelessWidget {
+  const ScheduleList({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_modal.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_modal.dart
@@ -54,7 +54,7 @@ class ScheduleClicked extends StatelessWidget {
                 children: [
                   SecondaryButton(
                       title: "취소하기",
-                      onPressed: (context) {
+                      onPressed: () {
                         Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -64,7 +64,7 @@ class ScheduleClicked extends StatelessWidget {
                   SizedBox(width: 12),
                   PrimaryButton(
                       title: "변경하기",
-                      onPressed: (context) {
+                      onPressed: () {
                         Navigator.push(
                             context,
                             MaterialPageRoute(

--- a/lib/pages/gymbie/gymbie_home/gymbie_home.dart
+++ b/lib/pages/gymbie/gymbie_home/gymbie_home.dart
@@ -31,7 +31,7 @@ class UserTimeTable extends StatelessWidget {
       ),
       drawer: UserDrawer(),
       body: Column(
-        children: [Calendar(), ScheduleList()],
+        children: [GymbieHomeCalendar(), GymbieScheduleList()],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/lib/pages/gymbie/gymbie_home/gymbie_home.dart
+++ b/lib/pages/gymbie/gymbie_home/gymbie_home.dart
@@ -31,7 +31,7 @@ class UserTimeTable extends StatelessWidget {
       ),
       drawer: UserDrawer(),
       body: Column(
-        children: [GymbieHomeCalendar(), ScheduleList()],
+        children: [GymbieHomeCalendar(), GymbieScheduleList()],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/lib/pages/gymbie/gymbie_home/gymbie_home.dart
+++ b/lib/pages/gymbie/gymbie_home/gymbie_home.dart
@@ -31,7 +31,7 @@ class UserTimeTable extends StatelessWidget {
       ),
       drawer: UserDrawer(),
       body: Column(
-        children: [GymbieHomeCalendar(), GymbieScheduleList()],
+        children: [GymbieHomeCalendar(), ScheduleList()],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {

--- a/lib/services/models/schedule_info.dart
+++ b/lib/services/models/schedule_info.dart
@@ -1,26 +1,19 @@
 class ScheduleInfo {
-  DateTime _startTime;
-  DateTime _endTime;
-  String _lessonName;
-  String _trainerName;
-  String _centerName;
-  String _centerLocation;
-  int _remainDays;
+  final DateTime _startTime;
+  final DateTime _endTime;
+  final String _lessonName;
+  final String _trainerName;
+  final String _centerName;
+  final String _centerLocation;
+  final int _remainDays;
 
   ScheduleInfo(this._startTime, this._endTime, this._lessonName,
       this._trainerName, this._centerName, this._centerLocation, this._remainDays);
-
   String get centerLocation => _centerLocation;
-
   String get centerName => _centerName;
-
   String get trainerName => _trainerName;
-
   String get lessonName => _lessonName;
-
   DateTime get endTime => _endTime;
-
   DateTime get startTime => _startTime;
-
   int get remainDays => _remainDays;
 }


### PR DESCRIPTION
## Changes
- 회원의 홈 화면(달력) 일정 표시 
- 회원의 홈 화면 일정의 오늘 날짜 색 빨간색으로 변경
- 회원의 홈 화면 하단 선택된 날짜의 일정 목록 구현 

## TODO
- 회원의 스케쥴 GET API 에 endtime 및 remain time 설정해주어야 함 
- schedule_info 모델에 factory pattern 구현 필요 

## Result
![Animation](https://github.com/AllideaBridge/gymming_app/assets/55073966/3cbb0f5d-46cc-4eb1-984a-2e87fb2d1db6)


