### PR TITLE
스케쥴 변경/취소 시 lessonChangeLimit 에 따라 추후 환경 변경되도록 수정 + 홈화면 수정 

### DIFF
--- a/lib/pages/gymbie/gymbie_home/component/gymbie_home_calendar.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_home_calendar.dart
@@ -9,7 +9,7 @@ import 'package:table_calendar/table_calendar.dart';
 import '../../../../common/colors.dart';
 
 class GymbieHomeCalendar extends StatefulWidget {
-  const GymbieHomeCalendar({Key? key}) : super(key: key);
+  const   GymbieHomeCalendar({Key? key}) : super(key: key);
 
   @override
   State<GymbieHomeCalendar> createState() => _GymbieHomeCalendarState();
@@ -61,9 +61,9 @@ class _GymbieHomeCalendarState extends State<GymbieHomeCalendar> {
         formatButtonVisible: false,
         rightChevronVisible: false,
         leftChevronVisible: false,
-        headerPadding: const EdgeInsets.all(8),
+        headerPadding: const EdgeInsets.only(left: 20, bottom: 20),
         titleTextStyle:
-            const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+            const TextStyle(color: Colors.white, fontWeight: FontWeight.w700, fontSize: 14),
         titleTextFormatter: (date, locale) =>
             "${date.year % 100} ${DateFormat.MMMM(locale).format(date).toUpperCase()}",
       ),

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_list.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:gymming_app/components/state_date_time.dart';
 import 'package:gymming_app/pages/gymbie/gymbie_home/component/gymbie_schedule_item.dart';
@@ -20,58 +19,63 @@ class GymbieScheduleList extends StatelessWidget {
     var selectedDateTime = Provider.of<StateDateTime>(context).selectedDateTime;
     schedules = scheduleRepository.getScheduleByDay(selectedDateTime);
 
-    return FutureBuilder(future: schedules, builder: (context, snapshot) {
-      if (snapshot.hasData) {
-        final schedules = snapshot.data!;
-        return buildScheduleList(schedules, selectedDateTime, context);
-      } else if (snapshot.hasError) {
-        return Text("${snapshot.error}", style: TextStyle(color: Colors.white),);
-      }
-      return const CircularProgressIndicator();
-    });
+    return Expanded(
+        child: Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        color: BACKGROUND_COLOR,
+      ),
+      margin: EdgeInsets.only(top: 54),
+      child: Container(
+        padding: EdgeInsets.fromLTRB(20, 32, 20, 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              DateUtil.getKoreanDay(selectedDateTime),
+              style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                  fontWeight: FontWeight.w500),
+            ),
+            SizedBox(width: 28, height: 28),
+            FutureBuilder(
+                future: schedules,
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    final schedules = snapshot.data!;
+                    return buildScheduleList(schedules, context);
+                  } else if (snapshot.hasError) {
+                    return SizedBox(
+                      width: double.infinity,
+                        child: Text("${snapshot.error}",
+                      style: TextStyle(color: Colors.white),
+                    ));
+                  }
+                  return const CircularProgressIndicator();
+                })
+          ],
+        ),
+      ),
+    ));
   }
 
-  Widget buildScheduleList(List<ScheduleInfo> schedules, DateTime selectedDateTime, context) {
+  Widget buildScheduleList(List<ScheduleInfo> schedules, context) {
     return Expanded(
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-          color: BACKGROUND_COLOR,
-        ),
-        margin: EdgeInsets.only(top: 54),
-        child: Container(
-          padding: EdgeInsets.fromLTRB(20, 32, 20, 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                DateUtil.getKoreanDay(selectedDateTime),
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 24,
-                    fontWeight: FontWeight.w500),
-              ),
-              SizedBox(width: 28, height: 28),
-              Expanded(
-                child: ListView(
-                  shrinkWrap: true,
-                  children: schedules
-                      .map((schedule) => GestureDetector(
-                      onTap: () {
-                        showScheduleBottomSheet(context, schedule);
-                      },
-                      child: Column(
-                        children: [
-                          ScheduleItem(scheduleInfo: schedule),
-                          SizedBox(width: 28, height: 28),
-                        ],
-                      )))
-                      .toList(),
-                ),
-              )
-            ],
-          ),
-        ),
+      child: ListView(
+        shrinkWrap: true,
+        children: schedules
+            .map((schedule) => GestureDetector(
+                onTap: () {
+                  showScheduleBottomSheet(context, schedule);
+                },
+                child: Column(
+                  children: [
+                    ScheduleItem(scheduleInfo: schedule),
+                    SizedBox(width: 28, height: 28),
+                  ],
+                )))
+            .toList(),
       ),
     );
   }

--- a/lib/pages/gymbie/gymbie_home/gymbie_home.dart
+++ b/lib/pages/gymbie/gymbie_home/gymbie_home.dart
@@ -16,16 +16,18 @@ class UserTimeTable extends StatelessWidget {
         titleTextStyle: TextStyle(color: Colors.white),
         title: const Text("Timetable"),
         actions: [
-          TextButton(
-            style: ButtonStyle(
-                foregroundColor: MaterialStatePropertyAll(Colors.white)),
-            child: Text('둘러보기'),
-            onPressed: () {
+          GestureDetector(
+            onTap: () {
               Navigator.push(context,
                   MaterialPageRoute(builder: (context) => ExploreScreen()));
             },
-          ),
-          Image.asset('assets/images/arrow.png')
+            child: Row(
+              children: [
+                Text('둘러보기', style: TextStyle(fontSize: 12, color: Colors.white),),
+                Icon(Icons.arrow_forward_ios_rounded, size: 12,)
+              ],
+            ),
+          )
         ],
         backgroundColor: Colors.black,
       ),

--- a/lib/pages/gymbie/gymbie_home/gymbie_home.dart
+++ b/lib/pages/gymbie/gymbie_home/gymbie_home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gymming_app/common/colors.dart';
 import 'package:gymming_app/pages/gymbie/drawer/gymbie_drawer.dart';
 import 'package:gymming_app/pages/gymbie/explore/explore_main.dart';
 import 'package:gymming_app/pages/gymbie/gymbie_home/component/gymbie_home_calendar.dart';
@@ -13,7 +14,12 @@ class UserTimeTable extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         iconTheme: IconThemeData(color: Colors.white),
-        titleTextStyle: TextStyle(color: Colors.white),
+        titleSpacing: 0,
+        titleTextStyle: TextStyle(
+            fontFamily: 'Montserrat',
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: Colors.white),
         title: const Text("Timetable"),
         actions: [
           GestureDetector(
@@ -23,8 +29,15 @@ class UserTimeTable extends StatelessWidget {
             },
             child: Row(
               children: [
-                Text('둘러보기', style: TextStyle(fontSize: 12, color: Colors.white),),
-                Icon(Icons.arrow_forward_ios_rounded, size: 12,)
+                Text(
+                  '둘러보기',
+                  style: TextStyle(fontSize: 12, color: Colors.white),
+                ),
+                Icon(
+                  Icons.arrow_forward_ios_rounded,
+                  size: 12,
+                ),
+                SizedBox(width: 20)
               ],
             ),
           )
@@ -33,7 +46,11 @@ class UserTimeTable extends StatelessWidget {
       ),
       drawer: UserDrawer(),
       body: Column(
-        children: [GymbieHomeCalendar(), GymbieScheduleList()],
+        children: [
+          advertisementContainer(),
+          GymbieHomeCalendar(),
+          GymbieScheduleList()
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
@@ -44,5 +61,31 @@ class UserTimeTable extends StatelessWidget {
         child: Icon(Icons.add),
       ),
     );
+  }
+
+  //타임테이블, 둘러보기 시 사용할 화면
+  Widget advertisementContainer() {
+    return Container(
+        width: double.infinity,
+        height: 80,
+        decoration: BoxDecoration(
+          color: BORDER_COLOR,
+          borderRadius: BorderRadius.all(Radius.circular(8.0)),
+        ),
+        margin: EdgeInsets.only(left: 20, right: 20, bottom: 20),
+        child: Padding(
+          padding: EdgeInsets.all(8),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Icon(
+                Icons.close,
+                color: Colors.white,
+                size: 20,
+              )
+            ],
+          ),
+        ));
   }
 }

--- a/lib/pages/gymbie/gymbie_schedule_cancel.dart
+++ b/lib/pages/gymbie/gymbie_schedule_cancel.dart
@@ -119,8 +119,8 @@ class GymbieScheduleCancel extends StatelessWidget {
           .difference(DateTime(now.year, now.month, now.day))
           .inDays;
 
-      if (days >= scheduleInfo.remainDays) {
-        //예약일까지의 날짜 차이가 remainDays보다 긴 경우 -> 즉시 취소 가능
+      //예약일까지의 날짜 차이가 lessonChangeLimit보다 긴 경우 -> 즉시 취소 가능
+      if (days >= scheduleInfo.lessonChangeLimit) {
         // api 호출
         var cancelResult = await scheduleRepository.cancelSchedule(scheduleInfo.scheduleId);
         //api 성공 -> 성공 페이지로 이동
@@ -137,7 +137,7 @@ class GymbieScheduleCancel extends StatelessWidget {
           //api 실패 -> 유지 (에러 메세지 띄우기?)
         }
       } else {
-        //예약일까지의 날짜 차이가 remainDays보다 짧은 경우 -> 취소 사유 입력
+        //예약일까지의 날짜 차이가 lessonChangeLimit보다 짧은 경우 -> 취소 사유 입력
         Navigator.push(
             context,
             MaterialPageRoute(

--- a/lib/pages/gymbie/gymbie_schedule_change/gymbie_schedule_change.dart
+++ b/lib/pages/gymbie/gymbie_schedule_change/gymbie_schedule_change.dart
@@ -122,7 +122,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
         .difference(DateTime(now.year, now.month, now.day))
         .inDays;
 
-    if (days >= widget.scheduleInfo.remainDays) {
+    if (days >= widget.scheduleInfo.lessonChangeLimit) {
       var requestTime = DateTime(
         _selectedDay.year,
         _selectedDay.month,

--- a/lib/services/models/schedule_info.dart
+++ b/lib/services/models/schedule_info.dart
@@ -5,7 +5,7 @@ class ScheduleInfo {
   final String _trainerName;
   final String _centerName;
   final String _centerLocation;
-  final int _remainDays;
+  final int _lessonChangeLimit;
 
   ScheduleInfo(
       this._scheduleId,
@@ -14,7 +14,7 @@ class ScheduleInfo {
       this._trainerName,
       this._centerName,
       this._centerLocation,
-      this._remainDays);
+      this._lessonChangeLimit);
 
   int get scheduleId => _scheduleId;
 
@@ -28,7 +28,7 @@ class ScheduleInfo {
 
   DateTime get startTime => _startTime;
 
-  int get remainDays => _remainDays;
+  int get lessonChangeLimit => _lessonChangeLimit;
 
   factory ScheduleInfo.fromJson(Map<String, dynamic> json) {
     return ScheduleInfo(
@@ -38,7 +38,6 @@ class ScheduleInfo {
         json["trainer_name"],
         json["center_name"],
         json["center_location"],
-        // TODO Remain Time 계산
-        5);
+        int.parse(json["lesson_change_range"]));
   }
 }


### PR DESCRIPTION
## changes
- 회원의 하루 스케줄 조회 api 시 스케줄 객체에 들어올 `lesson_change_range` 를 받아서 사용하기로 코드 적용
- 홈 화면의 상단 바를 디자인에 맞게 조정
- 홈 화면 스케줄을 불러오지 못할 경우 스케줄 목록 부분만 안보이도록 수정(날짜 표시 텍스트는 그대로 보임)
- 홈 화면을 디자인에 맞게 조정

## Result

![image](https://github.com/AllideaBridge/gymming_app/assets/55073966/36f248da-bb56-44b7-8714-84e82c823f68)
