### PR TITLE
[회원 스케쥴 조회/변경] schedule_detail 에 trainer_id 추가하여 스케쥴 변경 시 사용

### DIFF
--- a/lib/pages/gymbie/gymbie_schedule_change/gymbie_schedule_change.dart
+++ b/lib/pages/gymbie/gymbie_schedule_change/gymbie_schedule_change.dart
@@ -32,7 +32,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
   void _changeSelectedDay(DateTime selectedDay) async {
     var result =
         await ScheduleRepository.getAvailableTimeListByTrainerIdAndDate(
-            '1', selectedDay);
+            widget.scheduleDetail.trainerId, selectedDay);
     setState(() {
       _selectedDay = selectedDay;
       _selectedTime = '';

--- a/lib/pages/gympro/gympro_home/lesson_data_source.dart
+++ b/lib/pages/gympro/gympro_home/lesson_data_source.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gymming_app/common/colors.dart';
 import 'package:gymming_app/services/models/Meeting.dart';
 import 'package:gymming_app/services/models/lesson_list.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
@@ -7,7 +8,7 @@ class LessonDataSource extends CalendarDataSource {
   LessonDataSource(List<LessonList> source) {
     List<Meeting> meetings = [];
     for (LessonList lessonList in source) {
-      meetings.add(Meeting.fromLessonList(lessonList, Colors.yellow));
+      meetings.add(Meeting.fromLessonList(lessonList, PRIMARY_COLOR));
     }
     appointments = meetings;
   }

--- a/lib/services/models/schedule_detail.dart
+++ b/lib/services/models/schedule_detail.dart
@@ -1,5 +1,6 @@
 class ScheduleDetail {
   final int _scheduleId;
+  final int _trainerId;
   final DateTime _startTime;
   final String _lessonName;
   final String _trainerName;
@@ -9,6 +10,7 @@ class ScheduleDetail {
 
   ScheduleDetail(
       this._scheduleId,
+      this._trainerId,
       this._startTime,
       this._lessonName,
       this._trainerName,
@@ -17,6 +19,8 @@ class ScheduleDetail {
       this._lessonChangeRange);
 
   int get scheduleId => _scheduleId;
+
+  int get trainerId => _trainerId;
 
   String get centerLocation => _centerLocation;
 
@@ -33,6 +37,7 @@ class ScheduleDetail {
   factory ScheduleDetail.fromJson(Map<String, dynamic> json) {
     return ScheduleDetail(
         json["schedule_id"],
+        json["trainer_id"],
         DateTime.parse(json["schedule_start_time"]),
         json["lesson_name"],
         json["trainer_name"],
@@ -57,9 +62,9 @@ class ScheduleDetail {
   // api 완성되기 전 dummy 값
   static List<ScheduleDetail> getDummyScheduleDetailList() {
     return [
-      ScheduleDetail(1, DateTime.parse('2024-05-15T13:00:00'), 'ee', 'dummy',
+      ScheduleDetail(1, 1, DateTime.parse('2024-05-15T13:00:00'), 'ee', 'dummy',
           'dummy_center', 'dummy_loc', 3),
-      ScheduleDetail(1, DateTime.parse('2024-05-15T15:00:00'), 'ee', 'dummy',
+      ScheduleDetail(1, 1, DateTime.parse('2024-05-15T15:00:00'), 'ee', 'dummy',
           'dummy_center', 'dummy_loc', 3)
     ];
   }

--- a/lib/services/repositories/schedule_repository.dart
+++ b/lib/services/repositories/schedule_repository.dart
@@ -71,7 +71,7 @@ class ScheduleRepository {
     URL: schedules/trainer/<trainer_id>?date=date&type=day
    */
   static Future<List<AvailableTimes>> getAvailableTimeListByTrainerIdAndDate(
-      String trainerId, DateTime datetime) async {
+      int trainerId, DateTime datetime) async {
     Uri url =
         Uri.parse('$baseUrl/trainer/$trainerId').replace(queryParameters: {
       'date': DateUtil.convertDateTimeWithDash(datetime),


### PR DESCRIPTION
- https://gymming.atlassian.net/wiki/spaces/Gymming/pages/36012050/Schedule 에 회원 스케줄 조회 시 
- type=day 인 경우 응답에 trainer_id 추가하여 변경
- 스케줄 변경 시 하루의 트레이너 가능한 시간 보여주는 API에서 쿼리 파라미터로사용하는 trainer_id 를 이걸로 가져옴 