### PR TITLE
[Feature] 프로필 카드 컴포넌트 구현

### DIFF
--- a/lib/common/colors.dart
+++ b/lib/common/colors.dart
@@ -10,3 +10,4 @@ const Color BTN_COLOR = Color(0xff494949);
 const Color INDICATOR_COLOR = Color(0xff151515);
 const Color TERITARY_COLOR = Color(0xff7A7A7A);
 const Color CALENDAR_PICKED_COLOR = Color(0xffff7575);
+const Color CARD_BACK_GROUD_COLOR = Color(0xff3d3d3d);

--- a/lib/components/profile_card.dart
+++ b/lib/components/profile_card.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../common/colors.dart';
+
+class ProfileCard extends StatelessWidget {
+  final String imgUrl;
+  final String name;
+  final DateTime birth;
+  final String gender;
+  final String phoneNumber;
+  final String? additionalTitle;
+  final List<Widget>? additionalSub;
+
+  const ProfileCard({
+    super.key,
+    required this.imgUrl,
+    required this.name,
+    required this.birth,
+    required this.gender,
+    required this.phoneNumber,
+    this.additionalTitle,
+    this.additionalSub,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> children = [
+      _buildChildrenBasicWidget(),
+    ];
+    if (additionalTitle != null && additionalSub != null) {
+      children.add(Container(
+        margin: EdgeInsets.symmetric(vertical: 20.0),
+        width: double.infinity,
+        height: 2.0,
+        color: Colors.white,
+      ));
+      children.add(_buildChildrenAdditionalWidget());
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: CARD_BACK_GROUD_COLOR,
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      child: Column(
+        children: children,
+      ),
+    );
+  }
+
+  Widget _buildChildrenBasicWidget() {
+    return Row(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(50.0),
+          child: Image.asset(
+            imgUrl,
+            fit: BoxFit.cover,
+            width: 80.0,
+            height: 80.0,
+          ),
+        ),
+        SizedBox(width: 16.0),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              name,
+              style: TextStyle(
+                fontSize: 24.0,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            SizedBox(height: 8.0),
+            Row(
+              children: [
+                Text(
+                  DateFormat('yyyy.MM.DD').format(birth),
+                  style: TextStyle(
+                    fontSize: 16.0,
+                    color: BRIGHT_SECONDARY_COLOR,
+                  ),
+                ),
+                Container(
+                  width: 2.0,
+                  height: 16.0,
+                  color: BRIGHT_SECONDARY_COLOR,
+                  margin: EdgeInsets.symmetric(horizontal: 8.0),
+                ),
+                Text(
+                  gender,
+                  style: TextStyle(
+                    fontSize: 16.0,
+                    color: BRIGHT_SECONDARY_COLOR,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 8.0),
+            Text(
+              phoneNumber,
+              style: TextStyle(
+                fontSize: 16.0,
+                color: BRIGHT_SECONDARY_COLOR,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChildrenAdditionalWidget() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: _buildAdditionalWidgetWithSpacing(),
+    );
+  }
+
+  List<Widget> _buildAdditionalWidgetWithSpacing() {
+    List<Widget> additionalWidgets = [
+      Text(
+        additionalTitle!,
+        style: TextStyle(
+          fontSize: 24.0,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+      ),
+      SizedBox(height: 8.0),
+    ];
+    for (int i = 0; i < additionalSub!.length; i++) {
+      additionalWidgets.add(additionalSub![i]);
+      if (i < additionalSub!.length - 1) {
+        additionalWidgets.add(SizedBox(height: 8.0));
+      }
+    }
+    return additionalWidgets;
+  }
+}


### PR DESCRIPTION
## 사용법

```dart
ProfileCard(
  imgUrl: '',
  name: '',
  birth: '',
  gender: '',
  phoneNumber: '',
  // optional
  additionalTitle: '',
  additionalSub: [],
)
```

- additionalSub 의 경우 `List<Widget>` 형식으로 넘겨주어야 함.
- List에 담긴 Widget들이 서로 8px의 gap을 가지고 세로로 구현됨.

### 기본 사용
![component 3](https://github.com/AllideaBridge/gymming_app/assets/80023275/6938a176-1256-4380-aee2-270192f4d9f8)

### 확장 사용 1
![component 2](https://github.com/AllideaBridge/gymming_app/assets/80023275/8c5da146-9462-4fbb-87e4-685160975e84)

### 확장 사용 2
![component 1](https://github.com/AllideaBridge/gymming_app/assets/80023275/ce9d6cd1-8bd3-47cf-a174-ec276cc44090)
