### PR TITLE
ChangeTicket 요청 및 수락/거절 관련 API 연결 

### DIFF
--- a/lib/components/layouts/reason_layout.dart
+++ b/lib/components/layouts/reason_layout.dart
@@ -15,11 +15,10 @@ import 'reason_content.dart';
 class Reason extends StatefulWidget {
   final ReasonContent reasonContent;
   final ScheduleUser? scheduleDetail;
-  final DateTime? selectedDay;
   final DateTime? originalDay;
+  final DateTime? selectedDay;
   final String? selectedTime;
   final int? requestId;
-  final String type;
 
   const Reason(
       {super.key,
@@ -30,6 +29,8 @@ class Reason extends StatefulWidget {
       this.requestId,
       required this.type,
       this.originalDay});
+
+  final String type;
 
   @override
   ReasonState createState() => ReasonState();
@@ -236,7 +237,6 @@ class ReasonState extends State<Reason> {
                     onPressed: widget.type != REJECT
                         ? () async {
                             bool response = await sendCreateChangeTicket();
-
                             if (response) {
                               moveToCompletePage(context);
                             }
@@ -244,6 +244,7 @@ class ReasonState extends State<Reason> {
                         : () {
                             sendRejectChangeTicket();
                             _showToast('운동 일정 변경을 거절하셨습니다.');
+                            Navigator.pop(context);
                             Navigator.pop(context);
                           },
                     child: Text(
@@ -284,10 +285,15 @@ class ReasonState extends State<Reason> {
   void sendRejectChangeTicket() async {
     final body = {
       'change_from': 'TRAINER',
-      'change_type': 'REJECTED',
+      'change_type': 'MODIFY',
+      'status': 'REJECTED',
       'change_reason': clicked == 0
           ? textController.text
           : widget.reasonContent.reasons[clicked],
+      'reject_reason': clicked == 0
+          ? textController.text
+          : widget.reasonContent.reasons[clicked],
+      'start_time': DateUtil.convertDatabaseFormatDateTime(widget.selectedDay!)
     };
     await ChangeTicketRepository(client: http.Client())
         .modifyChangeTicket(widget.requestId!, body);

--- a/lib/components/layouts/reason_layout.dart
+++ b/lib/components/layouts/reason_layout.dart
@@ -16,6 +16,7 @@ class Reason extends StatefulWidget {
   final ReasonContent reasonContent;
   final ScheduleUser? scheduleDetail;
   final DateTime? selectedDay;
+  final DateTime? originalDay;
   final String? selectedTime;
   final int? requestId;
   final String type;
@@ -27,7 +28,8 @@ class Reason extends StatefulWidget {
       this.selectedDay,
       this.selectedTime,
       this.requestId,
-      required this.type});
+      required this.type,
+      this.originalDay});
 
   @override
   ReasonState createState() => ReasonState();
@@ -262,6 +264,7 @@ class ReasonState extends State<Reason> {
 
   Future<bool> sendCreateChangeTicket() async {
     final body = {
+      'schedule_id': widget.scheduleDetail?.scheduleId,
       'change_from': 'USER',
       'change_type': widget.type == CANCEL ? 'CANCEL' : 'MODIFY',
       'change_reason': clicked == 0
@@ -271,6 +274,7 @@ class ReasonState extends State<Reason> {
           ? DateUtil.convertDatabaseFormatFromDayAndTime(
               widget.selectedDay!, widget.selectedTime!)
           : null,
+      'as_is_date': DateUtil.convertDatabaseFormatDateTime(widget.originalDay!)
     };
     var response = await ChangeTicketRepository(client: http.Client())
         .createChangeTicket(body);

--- a/lib/components/layouts/tab_layout.dart
+++ b/lib/components/layouts/tab_layout.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../common/colors.dart';
 import '../common_header.dart';
 
-class Request extends StatelessWidget {
-  const Request(
+class TabLayout extends StatelessWidget {
+  const TabLayout(
       {super.key,
       required this.title,
       required this.leftTabName,

--- a/lib/pages/gymbie/drawer/gymbie_drawer.dart
+++ b/lib/pages/gymbie/drawer/gymbie_drawer.dart
@@ -127,7 +127,7 @@ class GymbieDrawer extends StatelessWidget {
               Navigator.push(
                   context,
                   MaterialPageRoute(
-                      builder: (context) => Request(
+                      builder: (context) => TabLayout(
                             title: "요청",
                             leftTabName: "응답 대기",
                             rightTabName: "완료",

--- a/lib/pages/gymbie/gymbie_schedule_change.dart
+++ b/lib/pages/gymbie/gymbie_schedule_change.dart
@@ -158,6 +158,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
                     scheduleDetail: widget.scheduleDetail,
                     selectedDay: _selectedDay,
                     selectedTime: _selectedTime,
+                    originalDay: widget.originDay,
                     type: CHANGE,
                   )));
     }

--- a/lib/pages/gympro/drawer/gympro_drawer.dart
+++ b/lib/pages/gympro/drawer/gympro_drawer.dart
@@ -6,6 +6,8 @@ import 'package:gymming_app/pages/gympro/gympro_register.dart';
 import '../../../common/colors.dart';
 import '../../../components/layouts/tab_layout.dart';
 import '../../../pages/gympro/gympro_member_mgmt/gympro_member_mgmt.dart';
+import '../gympro_requests/gympro_finished_request_list.dart';
+import '../gympro_requests/gympro_pending_request_list.dart';
 
 class TrainerDrawer extends StatelessWidget {
   const TrainerDrawer({super.key});
@@ -138,7 +140,7 @@ class TrainerDrawer extends StatelessWidget {
               Navigator.push(
                   context,
                   MaterialPageRoute(
-                      builder: (context) => Request(
+                      builder: (context) => TabLayout(
                             title: "기존 회원 관리",
                             leftTabName: "현재 등록 회원",
                             rightTabName: "이전 등록 회원",
@@ -150,23 +152,21 @@ class TrainerDrawer extends StatelessWidget {
           ListTile(
             contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 1.5),
             title: Text(
-              '알림 수신 관리',
+              '요청 목록',
               style: TextStyle(fontSize: 18, color: Colors.white),
             ),
-          ),
-          ListTile(
-            contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 1.5),
-            title: Text(
-              '광고 미노출 환경 구매',
-              style: TextStyle(fontSize: 18, color: Colors.white),
-            ),
-          ),
-          ListTile(
-            contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 1.5),
-            title: Text(
-              '앱 공지사항',
-              style: TextStyle(fontSize: 18, color: Colors.white),
-            ),
+            onTap: () {
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => TabLayout(
+                            title: "요청",
+                            leftTabName: "응답 대기",
+                            rightTabName: "완료",
+                            leftComponent: GymproPendingRequestList(),
+                            rightComponent: GymproFinishedRequestList(),
+                          )));
+            },
           ),
           ListTile(
             contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 1.5),

--- a/lib/pages/gympro/gympro_register.dart
+++ b/lib/pages/gympro/gympro_register.dart
@@ -101,7 +101,7 @@ class GymproRegisterState extends State<GymproRegister> {
   bool _validateStep1() {
     if (_model_step1['name'] == '') {
       return false;
-    } else if (ValidateUtil.isPhoneNumberValid(_model_step1['phoneNumber'])) {
+    } else if (!ValidateUtil.isPhoneNumberValid(_model_step1['phoneNumber'])) {
       return false;
     } else if (_model_step1['birth'] == null) {
       return false;

--- a/lib/pages/gympro/gympro_requests/gympro_finished_request_list.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_finished_request_list.dart
@@ -17,7 +17,7 @@ class GymproFinishedRequestList extends StatelessWidget {
       // TODO Status 값(RESOLVED) 상수화
       // TODO 무한 스크롤 page 늘어나는 기능 구현
       future: ChangeTicketRepository(client: http.Client())
-          .getChangeTicketList(1, 'RESOLVED', 1),
+          .getTrainerChangeTicketList(1, 'RESOLVED', 1),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return CircularProgressIndicator();
@@ -78,7 +78,7 @@ class GymproFinishedRequestList extends StatelessWidget {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  changeTicketList[index].userName,
+                                  changeTicketList[index].userName!,
                                   style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.bold,

--- a/lib/pages/gympro/gympro_requests/gympro_finished_request_list.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_finished_request_list.dart
@@ -17,7 +17,7 @@ class GymproFinishedRequestList extends StatelessWidget {
       // TODO Status 값(RESOLVED) 상수화
       // TODO 무한 스크롤 page 늘어나는 기능 구현
       future: ChangeTicketRepository(client: http.Client())
-          .getTrainerChangeTicketList(1, 'RESOLVED', 1),
+          .getTrainerChangeTicketList(1, 'APPROVED,REJECTED,CANCELED', 1),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return CircularProgressIndicator();
@@ -54,12 +54,6 @@ class GymproFinishedRequestList extends StatelessWidget {
                 children: [
                   ClipRRect(
                     borderRadius: BorderRadius.circular(50.0),
-                    child: Image.asset(
-                      changeTicketList[index].userProfileImage,
-                      fit: BoxFit.cover,
-                      width: 32.0,
-                      height: 32.0,
-                    ),
                   ),
                   SizedBox(
                     width: 12,
@@ -109,7 +103,8 @@ class GymproFinishedRequestList extends StatelessWidget {
                                 Icon(Icons.arrow_forward_rounded,
                                     size: 12, color: Colors.white),
                                 SizedBox(width: 8.0),
-                                changeTicketList[index].requestType == 'MODIFY'
+                                changeTicketList[index].changeTicketType ==
+                                        'MODIFY'
                                     ? Text(
                                         DateUtil.convertKoreanWithoutWeek(
                                             changeTicketList[index].toBeDate),
@@ -125,7 +120,7 @@ class GymproFinishedRequestList extends StatelessWidget {
                             ),
                           ],
                         ),
-                        changeTicketList[index].requestStatus == 'APPROVED'
+                        changeTicketList[index].changeTicketStatus == 'APPROVED'
                             ? PrimaryChip(title: '승인')
                             : GreyChip(title: '거절')
                       ],

--- a/lib/pages/gympro/gympro_requests/gympro_pending_request_list.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_pending_request_list.dart
@@ -15,7 +15,7 @@ class GymproPendingRequestList extends StatelessWidget {
       // TODO Status 값(WAITING) 상수화
       // TODO 무한 스크롤 page 늘어나는 기능 구현
       future: ChangeTicketRepository(client: http.Client())
-          .getChangeTicketList(1, 'WAITING', 1),
+          .getTrainerChangeTicketList(1, 'WAITING', 1),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return CircularProgressIndicator();
@@ -75,7 +75,7 @@ class GymproPendingRequestList extends StatelessWidget {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  changeTicketList[index].userName,
+                                  changeTicketList[index].userName!,
                                   style: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.bold,

--- a/lib/pages/gympro/gympro_requests/gympro_pending_request_list.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_pending_request_list.dart
@@ -52,12 +52,6 @@ class GymproPendingRequestList extends StatelessWidget {
                 children: [
                   ClipRRect(
                     borderRadius: BorderRadius.circular(50.0),
-                    child: Image.asset(
-                      changeTicketList[index].userProfileImage,
-                      fit: BoxFit.cover,
-                      width: 32.0,
-                      height: 32.0,
-                    ),
                   ),
                   SizedBox(
                     width: 12,
@@ -106,7 +100,8 @@ class GymproPendingRequestList extends StatelessWidget {
                                 Icon(Icons.arrow_forward_rounded,
                                     size: 12, color: Colors.white),
                                 SizedBox(width: 8.0),
-                                changeTicketList[index].requestType == 'MODIFY'
+                                changeTicketList[index].changeTicketType ==
+                                        'MODIFY'
                                     ? Text(
                                         DateUtil.convertKoreanWithoutWeek(
                                             changeTicketList[index].toBeDate),

--- a/lib/pages/gympro/gympro_requests/gympro_request_detail.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_request_detail.dart
@@ -15,6 +15,7 @@ import '../../../../common/colors.dart';
 import '../../../../common/constants.dart';
 import '../../../components/layouts/reason_content.dart';
 import '../../../components/layouts/reason_layout.dart';
+import '../../../services/utils/date_util.dart';
 import '../../../services/utils/toast_util.dart';
 
 class GymproRequestDetail extends StatefulWidget {
@@ -37,8 +38,8 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
     fToast = FToast();
     fToast.init(context);
     // TODO status 상수화
-    _isCompleted = widget.changeTicket.requestStatus != "WAITING";
-    _isAccepted = widget.changeTicket.requestStatus == "APPROVED";
+    _isCompleted = widget.changeTicket.changeTicketStatus != "WAITING";
+    _isAccepted = widget.changeTicket.changeTicketStatus == "APPROVED";
   }
 
   _showToast(msg) {
@@ -72,7 +73,8 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
                         ClipRRect(
                           borderRadius: BorderRadius.circular(50.0),
                           child: Image.asset(
-                            widget.changeTicket.userProfileImage,
+                            //todo user 상세조회하여 가져오기
+                            'assets/images/user_example.png',
                             fit: BoxFit.cover,
                             width: 48.0,
                             height: 48.0,
@@ -198,9 +200,11 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
                                                       REJECT_TITLE,
                                                       REJECT_SUBTITLE,
                                                       REJECT_REASONS),
-                                                  requestId: widget
-                                                      .changeTicket.requestId,
+                                                  requestId: widget.changeTicket
+                                                      .changeTicketId,
                                                   type: REJECT,
+                                                  selectedDay: widget
+                                                      .changeTicket.toBeDate,
                                                 )));
                                   }),
                               SizedBox(width: 12),
@@ -226,10 +230,14 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
   void sendApproveChangeTicket() async {
     final body = {
       'change_from': 'TRAINER',
+      'change_type': 'MODIFY',
       'status': 'APPROVED',
-      'start_time': widget.changeTicket.toBeDate,
+      'change_reason': widget.changeTicket.userMessage,
+      'reject_reason': '-',
+      'start_time':
+          DateUtil.convertDatabaseFormatDateTime(widget.changeTicket.toBeDate),
     };
     await ChangeTicketRepository(client: http.Client())
-        .modifyChangeTicket(widget.changeTicket.requestId, body);
+        .modifyChangeTicket(widget.changeTicket.changeTicketId, body);
   }
 }

--- a/lib/pages/gympro/gympro_requests/gympro_request_detail.dart
+++ b/lib/pages/gympro/gympro_requests/gympro_request_detail.dart
@@ -87,7 +87,7 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
                             Row(
                               children: [
                                 Text(
-                                  widget.changeTicket.userName,
+                                  widget.changeTicket.userName!,
                                   style: TextStyle(
                                       fontSize: 18,
                                       fontWeight: FontWeight.w600,

--- a/lib/services/models/change_ticket.dart
+++ b/lib/services/models/change_ticket.dart
@@ -1,6 +1,7 @@
 class ChangeTicket {
   final int _requestId;
-  final String _userName;
+  final String? _userName;
+  final String? _trainerName;
   final String _requestType;
   final DateTime _asIsDate;
   final DateTime? _toBeDate;
@@ -11,21 +12,23 @@ class ChangeTicket {
   final String? _trainerMessage;
 
   ChangeTicket(
-    this._requestId,
-    this._userName,
-    this._requestType,
-    this._asIsDate,
-    this._toBeDate,
-    this._createdAt,
-    this._requestStatus,
-    this._userProfileImage,
-    this._userMessage,
-    this._trainerMessage,
-  );
+      this._requestId,
+      this._userName,
+      this._trainerName,
+      this._requestType,
+      this._asIsDate,
+      this._toBeDate,
+      this._createdAt,
+      this._requestStatus,
+      this._userProfileImage,
+      this._userMessage,
+      this._trainerMessage);
 
   int get requestId => _requestId;
 
-  String get userName => _userName;
+  String? get userName => _userName;
+
+  String? get trainerName => _trainerName;
 
   String get requestType => _requestType;
 
@@ -47,6 +50,7 @@ class ChangeTicket {
     return ChangeTicket(
         json["request_id"],
         json["user_name"],
+        json["trainer_name"],
         json["request_type"],
         DateTime.parse(json["as_is_date"]),
         json["to_be_date"] == '' ? null : DateTime.parse(json["to_be_date"]),

--- a/lib/services/models/change_ticket.dart
+++ b/lib/services/models/change_ticket.dart
@@ -1,36 +1,34 @@
 class ChangeTicket {
-  final int _requestId;
+  final int _changeTicketId;
   final String? _userName;
   final String? _trainerName;
-  final String _requestType;
+  final String _changeTicketType;
   final DateTime _asIsDate;
   final DateTime? _toBeDate;
   final DateTime _createdAt;
-  final String _requestStatus;
-  final String _userProfileImage;
+  final String _changeTicketStatus;
   final String _userMessage;
   final String? _trainerMessage;
 
   ChangeTicket(
-      this._requestId,
+      this._changeTicketId,
       this._userName,
       this._trainerName,
-      this._requestType,
+      this._changeTicketType,
       this._asIsDate,
       this._toBeDate,
       this._createdAt,
-      this._requestStatus,
-      this._userProfileImage,
+      this._changeTicketStatus,
       this._userMessage,
       this._trainerMessage);
 
-  int get requestId => _requestId;
+  int get changeTicketId => _changeTicketId;
 
   String? get userName => _userName;
 
   String? get trainerName => _trainerName;
 
-  String get requestType => _requestType;
+  String get changeTicketType => _changeTicketType;
 
   DateTime get asIsDate => _asIsDate;
 
@@ -38,9 +36,7 @@ class ChangeTicket {
 
   DateTime get createdAt => _createdAt;
 
-  String get requestStatus => _requestStatus;
-
-  String get userProfileImage => _userProfileImage;
+  String get changeTicketStatus => _changeTicketStatus;
 
   String get userMessage => _userMessage;
 
@@ -48,15 +44,14 @@ class ChangeTicket {
 
   factory ChangeTicket.fromJson(Map<String, dynamic> json) {
     return ChangeTicket(
-        json["request_id"],
+        json["id"],
         json["user_name"],
         json["trainer_name"],
-        json["request_type"],
+        json["change_ticket_type"],
         DateTime.parse(json["as_is_date"]),
         json["to_be_date"] == '' ? null : DateTime.parse(json["to_be_date"]),
         DateTime.parse(json["created_at"]),
-        json["request_status"],
-        json["user_profile_image"],
+        json["change_ticket_status"],
         json["user_message"],
         json["trainer_message"] == '' ? null : json["trainer_message"]);
   }

--- a/lib/services/repositories/change_ticket_repository.dart
+++ b/lib/services/repositories/change_ticket_repository.dart
@@ -10,12 +10,12 @@ class ChangeTicketRepository {
   final http.Client client;
 
   // TODO 로컬 URL에서 변경 필요
-  final String baseUrl = "http://10.0.2.2:5000/change-tickets";
+  final String baseUrl = "http://10.0.2.2:5000/change-ticket";
 
   Future<List<ChangeTicket>> getChangeTicketList(
       int trainerId, String status, int page) async {
     var url = Uri.parse('$baseUrl/trainer/$trainerId')
-        .replace(queryParameters: {'status': status, 'page': page});
+        .replace(queryParameters: {'status': status, 'page': page.toString()});
 
     final response = await http.get(url);
 

--- a/lib/services/repositories/change_ticket_repository.dart
+++ b/lib/services/repositories/change_ticket_repository.dart
@@ -12,9 +12,27 @@ class ChangeTicketRepository {
   // TODO 로컬 URL에서 변경 필요
   final String baseUrl = "http://10.0.2.2:5000/change-ticket";
 
-  Future<List<ChangeTicket>> getChangeTicketList(
+  Future<List<ChangeTicket>> getTrainerChangeTicketList(
       int trainerId, String status, int page) async {
     var url = Uri.parse('$baseUrl/trainer/$trainerId')
+        .replace(queryParameters: {'status': status, 'page': page.toString()});
+
+    final response = await http.get(url);
+
+    if (response.statusCode == 200) {
+      try {
+        return ChangeTicket.parseChangeTicketList(json.decode(response.body));
+      } catch (e) {
+        throw Exception("Failed to load data");
+      }
+    } else {
+      throw Exception("Failed to load data");
+    }
+  }
+
+  Future<List<ChangeTicket>> getUserChangeTicketList(
+      int userId, String status, int page) async {
+    var url = Uri.parse('$baseUrl/user/$userId')
         .replace(queryParameters: {'status': status, 'page': page.toString()});
 
     final response = await http.get(url);

--- a/lib/services/repositories/change_ticket_repository.dart
+++ b/lib/services/repositories/change_ticket_repository.dart
@@ -57,7 +57,10 @@ class ChangeTicketRepository {
       },
     );
 
-    if (response.statusCode == 201) {
+    print(response.body);
+    print(response.statusCode);
+
+    if (response.statusCode == 200) {
       return true;
     } else {
       return false;
@@ -65,6 +68,7 @@ class ChangeTicketRepository {
   }
 
   Future<bool> modifyChangeTicket(int changeTicketId, Object body) async {
+    print(body);
     final response = await http.put(
       Uri.parse('$baseUrl/$changeTicketId'),
       body: json.encode(body),
@@ -72,6 +76,9 @@ class ChangeTicketRepository {
         'Content-Type': 'application/json',
       },
     );
+
+    //400 예외가 나오는 경우 메세지
+    // "Schedule is not changeable.Lesson change range overflow. schedule_id : *"
 
     if (response.statusCode == 201) {
       return true;

--- a/lib/services/utils/date_util.dart
+++ b/lib/services/utils/date_util.dart
@@ -65,6 +65,10 @@ class DateUtil {
     return DateFormat("yyyy-MM-dd").format(day);
   }
 
+  static String convertDatabaseFormatDateTime(DateTime dateTime) {
+    return DateFormat("yyyy-MM-dd HH:mm:ss").format(dateTime).toString();
+  }
+
   static String convertDatabaseFormatFromDayAndTime(DateTime day, String time) {
     var dateTime = DateTime(
       day.year,


### PR DESCRIPTION
## Changes
- api 명세에 맞게 요청/수락/거절/변경 등 api method와 파라미터를 변경
- 각 api parameter에 필요한 값들을 가져오기 위해 클래스별 멤버 변수 변경
- 유저/트레이너별 따로 요청 목록 api 메소드 분리

## TODO

- [ ]  트레이너의 요청 수락/거절 후 화면 갱신 및 돌아가는 화면 위치 결정 필요함
- [ ] 각 api 별로 400 등 예외 처리가 필요함
- [ ] 회원의 요청 목록은 아직 개발되지 않아 트레이너의 요청 목록과 동일함..(회원이 요청 목록을 볼 때 상세화면을 다르게 구성필요함)
- [ ] 승인/거절 이후 목록화면으로 이동하는 버튼 누르면 이상하게 화면이 변함.. 

## Result
1) 유저의 스케쥴 변경을 위한 change ticket 발행 화면
![ttt](https://github.com/user-attachments/assets/065c50e3-7417-4d85-ba1a-2f13101557be)

2) 트레이너의 요청 목록 확인 및 거절
![reject](https://github.com/user-attachments/assets/47f89da4-548a-46f3-8db4-f2b486fab05e)


3) 트레이너의 요청 목록 확인 및 수락
![approve](https://github.com/user-attachments/assets/5612abb7-d028-46c3-ba4f-b666044736b2)

