### PR TITLE
Change ticket API 오류 수정 및 보완

### DIFF
--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -67,5 +67,5 @@ class ChangeTicketStatus {
   static String APPROVED = "APPROVED";
   static String REJECTED = "REJECTED";
   static String CANCELED = "CANCELED";
-  static String RESOLVED = "APPROVED,REJECTED,CANCELED";
+  static String RESOLVED = "RESOLVED";
 }

--- a/lib/common/exceptions.dart
+++ b/lib/common/exceptions.dart
@@ -9,6 +9,7 @@ class TokenRefreshFailedException implements Exception {
 
 class UserNotRegisteredException implements Exception {
   final String message;
+
   UserNotRegisteredException([this.message = 'User not registered']);
 
   @override
@@ -17,7 +18,18 @@ class UserNotRegisteredException implements Exception {
 
 class TrainerNotRegisteredException implements Exception {
   final String message;
+
   TrainerNotRegisteredException([this.message = 'Trainer not registered']);
+
+  @override
+  String toString() => message;
+}
+
+class ChangeTicketCreateFailedException implements Exception {
+  final String message;
+
+  ChangeTicketCreateFailedException(
+      [this.message = 'ChangeTicketCreate failed']);
 
   @override
   String toString() => message;

--- a/lib/components/layouts/reason_layout.dart
+++ b/lib/components/layouts/reason_layout.dart
@@ -21,7 +21,7 @@ class ReasonLayout extends StatefulWidget {
   final ScheduleUser? scheduleDetail;
 
   //기존에 선택한 시간
-  final DateTime originalDay;
+  final DateTime originalDatetime;
 
   //새롭게 선택한 시간(오직 변경인 경우에만 해당함)
   final DateTime? selectedDay;
@@ -47,7 +47,7 @@ class ReasonLayout extends StatefulWidget {
       this.selectedTime,
       this.changeTicketId,
       required this.type,
-      required this.originalDay,
+      required this.originalDatetime,
       required this.requesterType,
       this.reasonFromUser});
 
@@ -115,29 +115,26 @@ class ReasonLayoutState extends State<ReasonLayout> {
                   title: '확인',
                   enabled: _selectedReason.isNotEmpty,
                   onPressed: () async {
-                    print(_selectedReason);
-                    print(widget.requesterType);
-                    print(widget.type);
-                    // if (widget.requesterType == 'TRAINER') {
-                    //   //trainer 의 change ticket 거절 api
-                    //   if (widget.type == ChangeTicketType.MODIFY) {
-                    //     rejectModifyTypeChangeTicket();
-                    //   } else {
-                    //     rejectCancelTypeChangeTicket();
-                    //   }
-                    //   _showToast('운동 일정 변경을 거절하셨습니다.');
-                    //   Navigator.pop(context);
-                    //   Navigator.pop(context);
-                    // } else {
-                    //   //user 의 change ticket 생성 api
-                    //   int changeTicketId;
-                    //   if (widget.type == ChangeTicketType.MODIFY) {
-                    //     changeTicketId = await createModifyTypeChangeTicket();
-                    //   } else {
-                    //     changeTicketId = await createCancelTypeChangeTicket();
-                    //   }
-                    //   moveToCompletePage(context, changeTicketId);
-                    // }
+                    if (widget.requesterType == 'TRAINER') {
+                      //trainer 의 change ticket 거절 api
+                      if (widget.type == ChangeTicketType.MODIFY) {
+                        rejectModifyTypeChangeTicket();
+                      } else {
+                        rejectCancelTypeChangeTicket();
+                      }
+                      _showToast('운동 일정 변경을 거절하셨습니다.');
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    } else {
+                      //user 의 change ticket 생성 api
+                      int changeTicketId;
+                      if (widget.type == ChangeTicketType.MODIFY) {
+                        changeTicketId = await createModifyTypeChangeTicket();
+                      } else {
+                        changeTicketId = await createCancelTypeChangeTicket();
+                      }
+                      moveToCompletePage(context, changeTicketId);
+                    }
                   }),
             ],
           ),
@@ -234,6 +231,7 @@ class ReasonLayoutState extends State<ReasonLayout> {
 
   //회원이 날리는 변경 타입 change ticket 생성 메소드
   Future<int> createModifyTypeChangeTicket() async {
+    print(DateUtil.convertDatabaseFormatDateTime(widget.originalDatetime));
     final body = {
       'schedule_id': widget.scheduleDetail?.scheduleId,
       'change_from': widget.requesterType,
@@ -241,7 +239,8 @@ class ReasonLayoutState extends State<ReasonLayout> {
       'change_reason': _selectedReason,
       'start_time': DateUtil.convertDatabaseFormatFromDayAndTime(
           widget.selectedDay!, widget.selectedTime!),
-      'as_is_date': DateUtil.convertDatabaseFormatDateTime(widget.originalDay)
+      'as_is_date':
+          DateUtil.convertDatabaseFormatDateTime(widget.originalDatetime)
     };
     int response = await ChangeTicketRepository().createChangeTicket(body);
     return response;
@@ -249,12 +248,14 @@ class ReasonLayoutState extends State<ReasonLayout> {
 
   //회원이 날리는 취소 타입 change ticket 생성 메소드
   Future<int> createCancelTypeChangeTicket() async {
+    print(DateUtil.convertDatabaseFormatDateTime(widget.originalDatetime));
     final body = {
       'schedule_id': widget.scheduleDetail?.scheduleId,
       'change_from': widget.requesterType,
       'change_type': widget.type,
       'change_reason': _selectedReason,
-      'as_is_date': DateUtil.convertDatabaseFormatDateTime(widget.originalDay)
+      'as_is_date':
+          DateUtil.convertDatabaseFormatDateTime(widget.originalDatetime)
     };
     int response = await ChangeTicketRepository().createChangeTicket(body);
     return response;

--- a/lib/components/layouts/reason_layout.dart
+++ b/lib/components/layouts/reason_layout.dart
@@ -9,6 +9,7 @@ import 'package:gymming_app/services/utils/date_util.dart';
 
 import '../../common/colors.dart';
 import '../../common/constants.dart';
+import '../../common/exceptions.dart';
 import '../../services/models/reason_content.dart';
 import '../../services/models/schedule_user.dart';
 import '../../services/utils/toast_util.dart';
@@ -128,12 +129,16 @@ class ReasonLayoutState extends State<ReasonLayout> {
                     } else {
                       //user 의 change ticket 생성 api
                       int changeTicketId;
-                      if (widget.type == ChangeTicketType.MODIFY) {
-                        changeTicketId = await createModifyTypeChangeTicket();
-                      } else {
-                        changeTicketId = await createCancelTypeChangeTicket();
+                      try {
+                        if (widget.type == ChangeTicketType.MODIFY) {
+                          changeTicketId = await createModifyTypeChangeTicket();
+                        } else {
+                          changeTicketId = await createCancelTypeChangeTicket();
+                        }
+                        moveToCompletePage(context, changeTicketId);
+                      } on ChangeTicketCreateFailedException catch (e) {
+                        _showToast(e.message);
                       }
-                      moveToCompletePage(context, changeTicketId);
                     }
                   }),
             ],

--- a/lib/pages/common/splash_screen.dart
+++ b/lib/pages/common/splash_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 
 import '../../common/exceptions.dart';
 import '../../services/repositories/auth_repository.dart';
-import 'package:http/http.dart' as http;
-
 import '../../state/info_state.dart';
 import '../gymbie/gymbie_home/gymbie_home.dart';
 import '../gympro/gympro_home/gympro_home.dart';

--- a/lib/pages/gymbie/drawer/gymbie_drawer.dart
+++ b/lib/pages/gymbie/drawer/gymbie_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gymming_app/common/constants.dart';
 import 'package:gymming_app/pages/gymbie/gymbie_register.dart';
 import 'package:gymming_app/pages/gympro/gympro_home/gympro_home.dart';
 import 'package:gymming_app/pages/sample/sample_page.dart';
@@ -92,10 +93,12 @@ class GymbieDrawer extends StatelessWidget {
                   onTap: () {
                     print('log out!');
                     TokenManagerService.instance.clearTokens();
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => LoginSelectType()));
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => LoginSelectType()),
+                      (Route<dynamic> route) => false,
+                    );
                   },
                   child: Container(
                     padding:
@@ -138,10 +141,10 @@ class GymbieDrawer extends StatelessWidget {
                             leftTabName: "응답 대기",
                             rightTabName: "완료",
                             leftComponent: GymbieChangeTicketList(
-                              changeTicketStatus: "WAITING",
+                              changeTicketStatus: ChangeTicketStatus.WAITING,
                             ),
                             rightComponent: GymbieChangeTicketList(
-                              changeTicketStatus: "APPROVED,REJECTED,CANCELED",
+                              changeTicketStatus: ChangeTicketStatus.RESOLVED,
                             ),
                           )));
             },

--- a/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_modal.dart
+++ b/lib/pages/gymbie/gymbie_home/component/gymbie_schedule_modal.dart
@@ -73,7 +73,7 @@ class GymbieScheduleModal extends StatelessWidget {
                             context,
                             MaterialPageRoute(
                                 builder: (context) => GymbieScheduleChange(
-                                      originDay:
+                                      originalSelectedDay:
                                           Provider.of<StateDateTime>(context)
                                               .selectedDateTime,
                                       scheduleDetail: scheduleDetail,

--- a/lib/pages/gymbie/gymbie_schedule_cancel.dart
+++ b/lib/pages/gymbie/gymbie_schedule_cancel.dart
@@ -146,7 +146,7 @@ class GymbieScheduleCancel extends StatelessWidget {
                     reasonContent: ReasonContent(
                         CANCEL_TITLE, CANCEL_SUBTITLE, CHANGE_REASONS),
                     scheduleDetail: scheduleDetail,
-                    originalDay: scheduleDetail.startTime,
+                    originalDatetime: scheduleDetail.startTime,
                     type: ChangeTicketType.CANCEL,
                     requesterType: 'USER',
                   )));

--- a/lib/pages/gymbie/gymbie_schedule_change.dart
+++ b/lib/pages/gymbie/gymbie_schedule_change.dart
@@ -6,8 +6,8 @@ import 'package:gymming_app/pages/gymbie/gymbie_schedule_resolve.dart';
 import 'package:gymming_app/services/models/available_times.dart';
 import 'package:gymming_app/services/repositories/schedule_repository.dart';
 import 'package:gymming_app/services/utils/date_util.dart';
-import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import '../../common/colors.dart';
 import '../../common/constants.dart';
@@ -18,11 +18,11 @@ import '../../services/models/schedule_user.dart';
 class GymbieScheduleChange extends StatefulWidget {
   const GymbieScheduleChange(
       {super.key,
-      required this.originDay,
+      required this.originalSelectedDay,
       required this.scheduleDetail,
       required this.userId});
 
-  final DateTime originDay;
+  final DateTime originalSelectedDay;
   final ScheduleUser scheduleDetail;
   final int userId;
 
@@ -34,7 +34,8 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
   DateTime _selectedDay = DateUtil.getKorTimeNow();
   String _selectedTime = '';
   List<AvailableTimes> _availableTimesList = [];
-  final ScheduleRepository scheduleRepository = ScheduleRepository(client: http.Client());
+  final ScheduleRepository scheduleRepository =
+      ScheduleRepository(client: http.Client());
 
   void _changeSelectedDay(DateTime selectedDay) async {
     List<AvailableTimes> trainerList =
@@ -68,7 +69,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
               children: [
                 CommonHeader(title: '일정 $CHANGE'),
                 ScheduleSelectCalendar(
-                  originDay: widget.originDay,
+                  originDay: widget.originalSelectedDay,
                   changeSelectedDay: _changeSelectedDay,
                 ),
                 const SizedBox(
@@ -127,7 +128,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
 
   void clickChangeButton(context) async {
     DateTime now = DateUtil.getKorTimeNow();
-    int days = widget.originDay
+    int days = widget.originalSelectedDay
         .difference(DateTime(now.year, now.month, now.day))
         .inDays;
 
@@ -160,7 +161,7 @@ class _GymbieScheduleChangeState extends State<GymbieScheduleChange> {
                     scheduleDetail: widget.scheduleDetail,
                     selectedDay: _selectedDay,
                     selectedTime: _selectedTime,
-                    originalDay: widget.originDay,
+                    originalDatetime: widget.scheduleDetail.startTime,
                     type: ChangeTicketType.MODIFY,
                     requesterType: 'USER',
                   )));

--- a/lib/pages/gymbie/gymbie_schedule_create.dart
+++ b/lib/pages/gymbie/gymbie_schedule_create.dart
@@ -3,8 +3,8 @@ import 'package:gymming_app/components/common_header.dart';
 import 'package:gymming_app/components/schedule_select_calendar.dart';
 import 'package:gymming_app/services/models/trainer_list.dart';
 import 'package:gymming_app/services/utils/date_util.dart';
-import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
+import 'package:intl/intl.dart';
 
 import '../../common/colors.dart';
 import '../../components/time_select_table.dart';
@@ -28,7 +28,8 @@ class _GymbieScheduleCreateState extends State<GymbieScheduleCreate> {
   DateTime _selectedDay = DateUtil.getKorTimeNow();
   String _selectedTime = '';
   List<AvailableTimes> _availableTimesList = [];
-  final ScheduleRepository scheduleRepository = ScheduleRepository(client: http.Client());
+  final ScheduleRepository scheduleRepository =
+      ScheduleRepository(client: http.Client());
 
   void _changeSelectedDay(DateTime selectedDay) async {
     List<AvailableTimes> trainerList =

--- a/lib/pages/gympro/drawer/gympro_drawer.dart
+++ b/lib/pages/gympro/drawer/gympro_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gymming_app/common/constants.dart';
 import 'package:gymming_app/pages/gymbie/gymbie_home/gymbie_home.dart';
 import 'package:gymming_app/pages/gympro/gympro_member_connect/gympro_member_search.dart';
 import 'package:gymming_app/pages/gympro/gympro_register.dart';
@@ -92,10 +93,12 @@ class TrainerDrawer extends StatelessWidget {
                   onTap: () {
                     print('log out!');
                     TokenManagerService.instance.clearTokens();
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => LoginSelectType()));
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => LoginSelectType()),
+                      (Route<dynamic> route) => false,
+                    );
                   },
                   child: Container(
                     padding:
@@ -170,10 +173,10 @@ class TrainerDrawer extends StatelessWidget {
                             leftTabName: "응답 대기",
                             rightTabName: "완료",
                             leftComponent: GymproChangeTicketList(
-                              changeTicketStatus: "WAITING",
+                              changeTicketStatus: ChangeTicketStatus.WAITING,
                             ),
                             rightComponent: GymproChangeTicketList(
-                              changeTicketStatus: "APPROVED,REJECTED,CANCELED",
+                              changeTicketStatus: ChangeTicketStatus.RESOLVED,
                             ),
                           )));
             },

--- a/lib/pages/gympro/gympro_change_ticket/gympro_request_detail.dart
+++ b/lib/pages/gympro/gympro_change_ticket/gympro_request_detail.dart
@@ -209,7 +209,7 @@ class _GymproRequestDetailState extends State<GymproRequestDetail> {
                                                           .changeTicketId,
                                                       type: widget.changeTicket
                                                           .changeTicketType,
-                                                      originalDay: widget
+                                                      originalDatetime: widget
                                                           .changeTicket
                                                           .asIsDate,
                                                       selectedDay: widget

--- a/lib/pages/login/login_select_social.dart
+++ b/lib/pages/login/login_select_social.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:gymming_app/pages/gympro/gympro_register.dart';
 import 'package:gymming_app/pages/login/component/login_footer.dart';
 import 'package:gymming_app/pages/login/component/login_header.dart';
 import 'package:gymming_app/services/auth/token_manager_service.dart';
 import 'package:http/http.dart' as http;
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:provider/provider.dart';
 
 import '../../common/colors.dart';
@@ -16,8 +16,6 @@ import '../../services/repositories/auth_repository.dart';
 import '../../state/info_state.dart';
 import '../gymbie/gymbie_home/gymbie_home.dart';
 import '../gymbie/gymbie_register.dart';
-import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
-
 import '../gympro/gympro_home/gympro_home.dart';
 
 class LoginSelectSocial extends StatelessWidget {
@@ -131,7 +129,7 @@ class LoginSelectSocial extends StatelessWidget {
                     TrainerAuth trainerAuth = await authRepository
                         .signInTrainer(oAuthToken.accessToken);
                     Provider.of<InfoState>(context, listen: false)
-                        .setUserId(trainerAuth.trainerId);
+                        .setTrainerId(trainerAuth.trainerId);
                     TokenManagerService.instance
                         .saveAccessToken(trainerAuth.accessToken);
                     TokenManagerService.instance

--- a/lib/services/repositories/change_ticket_repository.dart
+++ b/lib/services/repositories/change_ticket_repository.dart
@@ -6,7 +6,6 @@ import '../auth/api_service.dart';
 import '../models/change_ticket.dart';
 
 class ChangeTicketRepository extends ApiService {
-  // TODO 로컬 URL에서 변경 필요
   final String baseUrl = "$SERVER_URL/change-ticket";
 
   Future<List<ChangeTicket>> getTrainerChangeTicketList(

--- a/lib/services/repositories/change_ticket_repository.dart
+++ b/lib/services/repositories/change_ticket_repository.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:gymming_app/common/exceptions.dart';
+
 import '../../common/constants.dart';
 import '../auth/api_service.dart';
 import '../models/change_ticket.dart';
@@ -70,7 +72,8 @@ class ChangeTicketRepository extends ApiService {
     if (response.statusCode == 200) {
       return json.decode(response.body)['change_ticket_id'];
     } else {
-      throw Exception("create change ticket failed.");
+      throw ChangeTicketCreateFailedException(
+          jsonDecode(response.body)['message']);
     }
   }
 


### PR DESCRIPTION
## Changes
- change ticket 상태를 waiting / resolved 로 구분 (api 보낼 때)
- change ticket을 이미 생성한 적이 있는 스케줄은 다시 change ticket 생성하지 못하도록 막기 (토스트 팝업)
- 트레이너/회원 별 change ticket 목록 화면 자동 초기화 하도록 변경

## result 회원이 들어온 change ticket 거절하는 과정
![approve](https://github.com/user-attachments/assets/887c3bf3-6ac8-4768-b1a8-2483b07e73b5)
